### PR TITLE
Add support for multicharacter options to GUI

### DIFF
--- a/bad_ducky.ino
+++ b/bad_ducky.ino
@@ -17,7 +17,6 @@ String lang = "en";
 String payload;
 String prevCmd;
 String prevArg;
-String argString; // added to implement proper support for GUI combos
 char argChar;
 char prevArgChar;
 char charBuff;

--- a/bad_ducky.ino
+++ b/bad_ducky.ino
@@ -17,6 +17,7 @@ String lang = "en";
 String payload;
 String prevCmd;
 String prevArg;
+String argString; // added to implement proper support for GUI combos
 char argChar;
 char prevArgChar;
 char charBuff;
@@ -238,12 +239,7 @@ void delivery (String fileName) {
         if (breakChar == ' ') {
            parseArg(dataFile);
            arg = arg + '\n';
-          if (argString.length() == 1) {
-            cmdGui(argString.charAt(0));
-          }
-          else {
-            cmdKeyCombo(KEY_LEFT_GUI, arg);
-          }
+           cmdKeyCombo(KEY_LEFT_GUI, arg);
           //just to remove trailing \n
           //dataFile.read();
         }

--- a/bad_ducky.ino
+++ b/bad_ducky.ino
@@ -17,6 +17,7 @@ String lang = "en";
 String payload;
 String prevCmd;
 String prevArg;
+String argString; // added to implement proper support for GUI combos
 char argChar;
 char prevArgChar;
 char charBuff;
@@ -236,10 +237,16 @@ void delivery (String fileName) {
 
       if (cmd == "GUI" || cmd == "WINDOWS") {
         if (breakChar == ' ') {
-          argChar = dataFile.read();
-          cmdGui(argChar);
+           parseArg(dataFile);
+           arg = arg + '\n';
+          if (argString.length() == 1) {
+            cmdGui(argString.charAt(0));
+          }
+          else {
+            cmdKeyCombo(KEY_LEFT_GUI, arg);
+          }
           //just to remove trailing \n
-          dataFile.read();
+          //dataFile.read();
         }
         else {
           cmdGui(0x00);


### PR DESCRIPTION
On some systems, mainly macOS, you would want to use GUI (cmd on mac) with a character like space or even a function key. My change puts GUI in line with all of the other modifier keys, while still allowing GUI to be pressed on its own. If this change breaks anything, just let me know and I'll do my best to fix it. 

Best, 

Claire